### PR TITLE
Get priority from environment and set to a default value if not present in environment

### DIFF
--- a/kong/plugins/scalable-rate-limiter/handler.lua
+++ b/kong/plugins/scalable-rate-limiter/handler.lua
@@ -11,8 +11,9 @@ local EMPTY = {}
 
 local RateLimitingHandler = {}
 
-RateLimitingHandler.PRIORITY = 960
 RateLimitingHandler.VERSION = "2.2.0"
+RateLimitingHandler.PRIORITY = tonumber(os.getenv("PRIORITY_SCALABLE_RATE_LIMITER")) or 960
+kong.log.info("Plugin priority set to " .. RateLimitingHandler.PRIORITY .. (os.getenv("PRIORITY_SCALABLE_RATE_LIMITER") and " from env" or " by default"))
 
 local function get_identifier(conf)
     local identifier


### PR DESCRIPTION
### Summary

Enabled plugin to get priority from environment variable
