### PR TITLE
Add hostname resolution to ip

### DIFF
--- a/.pongo/redis-cluster.yml
+++ b/.pongo/redis-cluster.yml
@@ -9,6 +9,7 @@ networks:
 services:
   redis-cluster:
     image: redis:latest
+    hostname: pongo-test-network
     command: redis-cli -p 7101 --cluster create 172.18.55.1:7101 172.18.55.2:7102 172.18.55.3:7103 --cluster-yes
     depends_on:
       - redis-1

--- a/kong-scalable-rate-limiter-1.1.0-1.rockspec
+++ b/kong-scalable-rate-limiter-1.1.0-1.rockspec
@@ -14,7 +14,7 @@ description = {
 }
 
 dependencies = {
-    "lua-resty-ipmatcher == 0.6.1-0",
+    "lua-resty-ipmatcher == 0.6.1",
 }
 
 build = {

--- a/kong-scalable-rate-limiter-1.1.0-1.rockspec
+++ b/kong-scalable-rate-limiter-1.1.0-1.rockspec
@@ -14,7 +14,7 @@ description = {
 }
 
 dependencies = {
-
+    "lua-resty-ipmatcher == 0.6.1-0",
 }
 
 build = {

--- a/kong/plugins/scalable-rate-limiter/policies/connection.lua
+++ b/kong/plugins/scalable-rate-limiter/policies/connection.lua
@@ -3,6 +3,8 @@ local redis_cluster = require "resty.rediscluster"
 local resty_lock = require "resty.lock"
 local worker = ngx.worker
 local inspect = require "inspect"
+local dns_client = require "kong.resty.dns.client"
+local ip   = require "resty.mediador.ip"
 local _M = {}
 
 local data = {
@@ -10,6 +12,12 @@ local data = {
 }
 
 local function get_redis_config(source_config)
+    -- If not ipv4 and not ipv6 adress then we need to resolve hostname to ip
+    if not ip.isv4(source_config.redis_host) and not ip.isv6(source_config.redis_host) then
+      dns_client = require("kong.tools.dns")(kong.configuration)  -- configure DNS client
+      source_config.redis_host = dns_client.toip(source_config.redis_host)
+    end
+    
     return {
         name = "d11-redis-cluster",
         serv_list = {

--- a/kong/plugins/scalable-rate-limiter/policies/connection.lua
+++ b/kong/plugins/scalable-rate-limiter/policies/connection.lua
@@ -4,7 +4,7 @@ local resty_lock = require "resty.lock"
 local worker = ngx.worker
 local inspect = require "inspect"
 local dns_client = require "kong.resty.dns.client"
-local ip   = require "resty.mediador.ip"
+local ipmatcher = require "resty.ipmatcher"
 local _M = {}
 
 local data = {
@@ -13,7 +13,7 @@ local data = {
 
 local function get_redis_config(source_config)
     -- If not ipv4 and not ipv6 adress then we need to resolve hostname to ip
-    if not ip.isv4(source_config.redis_host) and not ip.isv6(source_config.redis_host) then
+    if not ipmatcher.parse_ipv4(source_config.redis_host) and not ipmatcher.parse_ipv6(source_config.redis_host) then
       dns_client = require("kong.tools.dns")(kong.configuration)  -- configure DNS client
       source_config.redis_host = dns_client.toip(source_config.redis_host)
     end


### PR DESCRIPTION
### Allows the redis host to be an ip or a true resolvable hostname much like the field redis_host implies.

Uses the same libs and such that Kong uses and since this is a Kong plugin I think makes sense to just reuse their ways. 